### PR TITLE
Improve styling for highlighted text

### DIFF
--- a/slides/styles.css
+++ b/slides/styles.css
@@ -138,3 +138,9 @@
 .reveal .tiny p + ol {
   margin-top: 0em;
 }
+
+/* Text Highlighting */
+.reveal ::selection {
+  background: #c6dcbe;
+  color: inherit !important;
+}


### PR DESCRIPTION
Sets the text highlight color to a light green (#c6dcbe) and enforces the text color to remain the same as before highlighting. This increases contrast and makes the highlighted text much more visible from a distance.

Before:
<img width="1165" height="283" alt="Before" src="https://github.com/user-attachments/assets/75fe6abd-17df-4dd4-a1ed-583aaa72d41e" />
After:
<img width="1165" height="283" alt="After" src="https://github.com/user-attachments/assets/4e1e3e37-5fb9-4365-87bf-061ba88dacc3" />

